### PR TITLE
docs: Add CC BY 4.0 to LICENSE for non-code materials

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,33 @@
-MIT License
+# Instructional Material
+
+All reports and non-software related materials including tables, plots and images under this project is
+made available under the **Creative Commons Attribution 4.0 International License** ([CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). 
+
+## You are free to:
+**Share** — copy and redistribute the material in any medium or format for any purpose, even commercially.
+
+**Adapt** — remix, transform, and build upon the material for any purpose, even commercially.
+ 
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+## Under the following terms:
+
+**Attribution** — You must give [appropriate credit](https://creativecommons.org/licenses/by/4.0/#ref-appropriate-credit), provide a link to the license, and [indicate if changes were made](https://creativecommons.org/licenses/by/4.0/#ref-indicate-changes). You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. 
+
+**No additional restrictions** — You may not apply legal terms or [technological measures](https://creativecommons.org/licenses/by/4.0/#ref-technological-measures) that legally restrict others from doing anything the license permits.
+
+## Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable [exception or limitation](https://creativecommons.org/licenses/by/4.0/#ref-exception-or-limitation).
+
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as [publicity, privacy, or moral rights](https://creativecommons.org/licenses/by/4.0/#ref-publicity-privacy-or-moral-rights) may limit how you use the material.
+
+# Software
+
+Except where otherwise noted, the programs and other software
+provided in this repository are made available under the MIT license.
+
+**MIT License**
 
 Copyright (c) 2024, John Shiu, Orix Au Yeung, Tony Shum, Yingzi Jin
 


### PR DESCRIPTION
This PR revises `LICENSE` file to include Creative Commons Attribution 4.0 International License to non-code/non-software materials.

Closes #26.