### PR TITLE
docs: Fix wrong surname-lastname order in references

### DIFF
--- a/checklist/checklist.yaml
+++ b/checklist/checklist.yaml
@@ -102,7 +102,7 @@ Test Areas:
           project by ensuring data is available from the start.
         References:
           - msise2023
-      
+
       - Title: Data in the Expected Format
         Requirement: >
           Check that the data to be ingested is in the format expected by the

--- a/checklist/references.bib
+++ b/checklist/references.bib
@@ -10,7 +10,7 @@
 
 @misc{winters2024,
 	title        = {Test Failures Should Be Actionable},
-	author       = {Titus, Winters},
+	author       = {Winters, Titus},
 	year         = 2024,
 	month        = {May},
 	journal      = {Google Testing Blog},
@@ -20,7 +20,7 @@
 
 @misc{yu2018,
 	title        = {Testing on the Toilet: Keep Tests Focused},
-	author       = {Ben, Yu},
+	author       = {Yu, Ben},
 	year         = 2018,
 	month        = {June},
 	journal      = {Google Testing Blog},
@@ -30,7 +30,7 @@
 
 @misc{kent2024,
 	title        = {Prefer Narrow Assertions in Unit Tests},
-	author       = {Kai, Kent},
+	author       = {Kent, Kai},
 	year         = 2024,
 	month        = {April},
 	journal      = {Google Testing Blog},
@@ -40,7 +40,7 @@
 
 @misc{yu2017,
 	title        = {Testing on the Toilet: Keep Cause and Effect Clear},
-	author       = {Ben, Yu},
+	author       = {Yu, Ben},
 	year         = 2017,
 	month        = {January},
 	journal      = {Google Testing Blog},


### PR DESCRIPTION
This fixes the wrong name format used in the `references.bib` file. For some resources, the author's name is listed in the order of `{last name, surname}` whereas the correct format should be `{surname, last name}`.