### PR TITLE
feat: Add functionalities to read and export the checklist in CSV format

### DIFF
--- a/checklist/checklist.yaml
+++ b/checklist/checklist.yaml
@@ -4,80 +4,88 @@ Title: Checklist for Tests in Machine Learning Projects
 # TODO: To be filled in later...
 Description: Description about the project and its context
 Test Areas:
-  - Topic: General
-    Description: >
+  - ID: "1"
+    Topic: General
+    Description: >-
       The following items describe best practices for all tests to be written.
     Tests:
-      - Title: Write Descriptive Test Names
-        Requirement: >
+      - ID: "1.1"
+        Title: Write Descriptive Test Names
+        Requirement: >-
           Every test function should have a clear, descriptive name
-        Explanation: >
+        Explanation: >-
           If out tests are narrow and sufficiently descriptive, the test name
-          itself may give us enough information to start debugging.  This also
+          itself may give us enough information to start debugging. This also
           helps us to identify what is being tested inside the function.
         References:
           - trenk2014
           - winters2024
 
-      - Title: Keep Tests Focused
-        Requirement: >
+      - ID: "1.2"
+        Title: Keep Tests Focused
+        Requirement: >-
           Each test should only test one scenario, meaning that in each test we
           should only use one set of mock data.
-        Explanation: >
+        Explanation: >-
           If we test multiple scenarios in a single test, it is hard to idenitfy
           exactly what went wrong. Keeping one scenario in a single test helps
           us to isolate problematic scenarios.
         References:
           - yu2018
 
-      - Title: Prefer Narrow Assertions in Unit Tests
-        Requirement: >
+      - ID: "1.3"
+        Title: Prefer Narrow Assertions in Unit Tests
+        Requirement: >-
           The assertions inside the tests should be narrow, meaning that when
           checking a complex object, any unrelated behavior should not be tested
           - Assert on only relevant behaviors.
-        Explanation: >
+        Explanation: >-
           If we have overly wide assertions (such as depending on every field of
           a complex output proto), the test may fail for many unimportant
           reasons. False positives are the opoosite of actionable.
         References:
           - kent2024
 
-      - Title: Keep Cause and Effect Clear
-        Requirement: >
+      - ID: "1.4"
+        Title: Keep Cause and Effect Clear
+        Requirement: >-
           The modifications and the assertions of an object's behavior in a
           single test should not be far away from each other.
-        Explanation: >
+        Explanation: >-
           Refrain from using large global test data structures shared across
           multiple unit tests. This will allow for clear identification of each
           test's setup and the cause and effect.
         References:
           - yu2017
 
-  - Topic: Data Presence
-    Description: >
+  - ID: "2"
+    Topic: Data Presence
+    Description: >-
       The following items describe tests that need to be done for testing the
       presence of data. This area of tests mainly concern whether the reading
       and saving operations are behaving as expected, and any unexpected
       behavior would not be passed silently.
     Tests:
-      - Title: Ensure Data File Loads as Expected
-        Requirement: >
+      - ID: "2.1"
+        Title: Ensure Data File Loads as Expected
+        Requirement: >-
           Verify the function for loading data files load the file if the files
           exists with the right format, and doesn't load the file if it doesn't
           exist, and that it returns the expected results.
-        Explanation: >
+        Explanation: >-
           Reading data is a common scenario encountered in ML projects.  This
           item ensures that the data exists and can be loaded with expected
           format, and gracefully exit when unable to load the data.
         References:
           - msise2023
 
-      - Title: Ensure Saving Data/Figures Function Works as Expected
-        Requirement: >
+      - ID: "2.2"
+        Title: Ensure Saving Data/Figures Function Works as Expected
+        Requirement: >-
           Verify the functions for saving data and figures can write as
           expected. They should check the if the write operation is successfully
           carried out, and the content is in an expected format.
-        Explanation: >
+        Explanation: >-
           Writing operations create artifacts at different stages of the
           analysis. Making sure the artifacts are created as expected ensures
           that the artifacts we obtained at the end of the analysis would be
@@ -85,44 +93,48 @@ Test Areas:
         References:
           - msise2023
 
-  - Topic: Data Quality
-    Description: >
+  - ID: "3"
+    Topic: Data Quality
+    Description: >-
       The following items describe tests that need to be done for testing the
       quality of data. This area of tests mainly concern whether the data
       supplied is in the expected format, data containing null values or
       outliers to make sure that the data processing pipeline is robust.
     Tests:
-      - Title: Files Contain Data
-        Requirement: >
+      - ID: "3.1"
+        Title: Files Contain Data
+        Requirement: >-
           Ensure that all data files are non-empty and contain the necessary
           data to proceed with the analysis or processing tasks.
-        Explanation: >
+        Explanation: >-
           This checklist item is crucial as it confirms the presence of usable
           data within the files. It prevents errors in later stages of the
           project by ensuring data is available from the start.
         References:
           - msise2023
       
-      - Title: Data in the Expected Format
-        Requirement: >
+      - ID: "3.2"
+        Title: Data in the Expected Format
+        Requirement: >-
           Check that the data to be ingested is in the format expected by the
           processing algorithms (e.g., Is the CSV loaded as a `pd.DataFrame`? Is
           the image file loaded as a `np.array`, or a `PIL.Image`?) and that
           their structure matches the expected schema, any present.
-        Explanation: >
+        Explanation: >-
           Ensuring that data and images are in the correct format is essential
           for compatibility with processing tools and algorithms, which may not
           handle unexpected formats gracefully.
         References:
           - msise2023
 
-      - Title: Data Does Not Contain Null Values or Outliers
-        Requirement: >
+      - ID: "3.3"
+        Title: Data Does Not Contain Null Values or Outliers
+        Requirement: >-
           Verify that the data files are free of unexpected null values and
           identify any outliers that may skew the results or affect the
           analysis. If null values are expected, it must be explicitly stated
           in the tests.
-        Explanation: >
+        Explanation: >-
           Null values can lead to errors or inaccurate computations in many
           data processing applications, while outliers can distort statistical
           analyses and models. As such, these values should be checked when
@@ -130,93 +142,102 @@ Test Areas:
         References:
           - msise2023
 
-  - Topic: Data Ingestion
-    Description: >
+  - ID: "4"
+    Topic: Data Ingestion
+    Description: >-
       The following items describe tests that need to be done for testing if the
       data is ingestion properly.
     Tests:
-      - Title: Cleaning and Transformation Functions Work as Expected
-        Requirement: >
+      - ID: "4.1"
+        Title: Cleaning and Transformation Functions Work as Expected
+        Requirement: >-
           Test input and output so that a fixed input would get an expected
           output. One such test could be testing the output shap of the data
           after transformation. Ideally, each test should be limited to test
           just one verification.
-        Explanation: >
+        Explanation: >-
           Fixed input and output during the data cleaning and transformation
           routines should be tested so that no unexpected transformation is
           introduced during these steps.
         References:
           - msise2023
 
-  - Topic: Model Fitting
-    Description: >
+  - ID: "5"
+    Topic: Model Fitting
+    Description: >-
       The following items describe tests that need to be done for testing the
       model fitting process. The unit tests written for this section usually
       mock model load and model predictions similarly to mocking file access.
     Tests:
-      - Title: Validate Model Input and Output Compatibility
-        Requirement: >
+      - ID: "5.1"
+        Title: Validate Model Input and Output Compatibility
+        Requirement: >-
           Confirm that the model accepts the correct input shapes and types,
           and produces outputs of the expected shapes and types without errors.
-        Explanation: >
+        Explanation: >-
           Ensuring that inputs and outputs conform to expected specifications
           is critical for the correct functioning of the model in a production
           environment.
         References:
           - msise2023
 
-      - Title: Check Model is Learning During Fit
-        Requirement: >
+      - ID: "5.2"
+        Title: Check Model is Learning During Fit
+        Requirement: >-
           If a parametric model is used during the training process, make sure
           that the model's weights are being updated correctly as expected per
           training iteration. If a non-parametric model is used, check if the
           data is fitted into the model.
-        Explanation: >
+        Explanation: >-
           Making sure the training process is indeed training the model is
           crucial as model without training is not fitted to any data and the
           performance would suffer.
         References:
           - msise2023
 
-      - Title: Ensure Model Output Shape Aligns with Expectation
-        Requirement: >
+      - ID: "5.3"
+        Title: Ensure Model Output Shape Aligns with Expectation
+        Requirement: >-
           Ensure that the shape of model output aligns with what is expected
           based the task of the model. For example, in classification task, the
           shape of the model output should be aligned with the number of labels
           in the dataset.
-        Explanation: >
+        Explanation: >-
           Correct output alignment confirms that the model is accurately
           interpreting the input data and making predictions that are sensible
           given the context.
         References:
           - jordan2020
 
-      - Title: Ensure Model Output Aligns with Task Trained
-        Requirement: >
+      - ID: "5.4"
+        Title: Ensure Model Output Aligns with Task Trained
+        Requirement: >-
           Verify that the output values are aligned with the task of the model.
           For example, a classification model would output probabilities which
           should sum to 1.
-        Explanation: >
+        Explanation: >-
           This ensures that the model's output is interpretable and relevant to
           the task it was trained for.
         References:
           - jordan2020
 
-      - Title: Validate Loss Reduction on Gradient Update
-        Requirement: >
+      - ID: "5.5"
+        Title: Validate Loss Reduction on Gradient Update
+        Requirement: >-
           If the model relies on gradient descent for training, make sure a
           single gradient step on a batch of data yields a decrease in the
           model's training loss.
-        Explanation: >
+        Explanation: >-
           A decrease in training loss after a gradient update demonstrates that
           the data is adequate to be fitted into the model.
         References:
           - jordan2020
 
-      - Title: Check for Data Leakage
-        Requirement: >
+      - ID: "5.6"
+        Title: Check for Data Leakage
+        Requirement: >-
           Confirm that there is no leakage between train/val/test or CV splits.
-        Explanation: >
+        Explanation: >-
           Data leakage can compromise the model's ability to generalize to
           unseen data, making it crucial to ensure datasets are properly
           segregated.
@@ -224,30 +245,34 @@ Test Areas:
           - jordan2020
 
 
-  - Topic: Model Evaluation
-    Description: >
+  - ID: "6"
+    Topic: Model Evaluation
+    Description: >-
       The following items describe tests that need to be done for testing the
       model evaluation process.
     Tests:
-      - Title: Dummy Title
-        Requirement: >
+      - ID: "6.1"
+        Title: Dummy Title
+        Requirement: >-
           This is a dummy item and there is nothing needed to act on.
-        Explanation: >
+        Explanation: >-
           This is a dummy item to show how the checklist items would be stored
           inside this YAML file. It serves no other purpose.
         References:
           - http://128.0.0.1
           - UBC-MDS
 
-  - Topic: Artifact Testing
-    Description: >
+  - ID: "7"
+    Topic: Artifact Testing
+    Description: >-
       The following items describe tests that need to be done for testing any
       artifacts that are created from the project.
     Tests:
-      - Title: Dummy Title
-        Requirement: >
+      - ID: "7.1"
+        Title: Dummy Title
+        Requirement: >-
           This is a dummy item and there is nothing needed to act on.
-        Explanation: >
+        Explanation: >-
           This is a dummy item to show how the checklist items would be stored
           inside this YAML file. It serves no other purpose.
         References:

--- a/checklist/checklist.yaml
+++ b/checklist/checklist.yaml
@@ -12,7 +12,9 @@ Test Areas:
       - ID: "1.1"
         Title: Write Descriptive Test Names
         Requirement: >
-          Each test function should have a clear, descriptive name that accurately reflects the test's purpose and the specific functionality or scenario it examines.
+          Each test function should have a clear, descriptive name that
+          accurately reflects the test's purpose and the specific functionality
+          or scenario it examines.
         Explanation: >
           If out tests are narrow and sufficiently descriptive, the test name
           itself may give us enough information to start debugging. This also
@@ -24,7 +26,9 @@ Test Areas:
       - ID: "1.2"
         Title: Keep Tests Focused
         Requirement: >
-          Each test should focus on a single scenario, using only one set of mock data and testing one specific behavior or outcome to ensure clarity and isolate issues.
+          Each test should focus on a single scenario, using only one set of
+          mock data and testing one specific behavior or outcome to ensure
+          clarity and isolate issues.
         Explanation: >
           If we test multiple scenarios in a single test, it is hard to idenitfy
           exactly what went wrong. Keeping one scenario in a single test helps
@@ -35,7 +39,9 @@ Test Areas:
       - ID: "1.3"
         Title: Prefer Narrow Assertions in Unit Tests
         Requirement: >
-          Assertions within tests should be focused and narrow. Ensure you are only testing relevant behaviors of complex objects and not including unrelated assertions.
+          Assertions within tests should be focused and narrow. Ensure you are
+          only testing relevant behaviors of complex objects and not including
+          unrelated assertions.
         Explanation: >
           If we have overly wide assertions (such as depending on every field of
           a complex output proto), the test may fail for many unimportant
@@ -46,7 +52,9 @@ Test Areas:
       - ID: "1.4"
         Title: Keep Cause and Effect Clear
         Requirement: >
-          Keep any modifications to objects and the corresponding assertions close together in your tests to maintain readability and clearly show the cause-and-effect relationship.
+          Keep any modifications to objects and the corresponding assertions
+          close together in your tests to maintain readability and clearly show
+          the cause-and-effect relationship.
         Explanation: >
           Refrain from using large global test data structures shared across
           multiple unit tests. This will allow for clear identification of each
@@ -65,7 +73,9 @@ Test Areas:
       - ID: "2.1"
         Title: Ensure Data File Loads as Expected
         Requirement: >
-          Ensure that data-loading functions correctly load files when they exist and match the expected format, handle non-existent files appropriately, and return the expected results.
+          Ensure that data-loading functions correctly load files when they
+          exist and match the expected format, handle non-existent files
+          appropriately, and return the expected results.
         Explanation: >
           Reading data is a common scenario encountered in ML projects.  This
           item ensures that the data exists and can be loaded with expected
@@ -76,7 +86,9 @@ Test Areas:
       - ID: "2.2"
         Title: Ensure Saving Data/Figures Function Works as Expected
         Requirement: >
-          Verify that functions for saving data and figures perform write operations correctly, checking that the operation succeeds and the content matches the expected format.
+          Verify that functions for saving data and figures perform write
+          operations correctly, checking that the operation succeeds and the
+          content matches the expected format.
         Explanation: >
           Writing operations create artifacts at different stages of the
           analysis. Making sure the artifacts are created as expected ensures
@@ -96,18 +108,21 @@ Test Areas:
       - ID: "3.1"
         Title: Files Contain Data
         Requirement: >
-          Ensure all data files are non-empty and contain the necessary data required for further analysis or processing tasks.
+          Ensure all data files are non-empty and contain the necessary data
+          required for further analysis or processing tasks.
         Explanation: >
           This checklist item is crucial as it confirms the presence of usable
           data within the files. It prevents errors in later stages of the
           project by ensuring data is available from the start.
         References:
           - msise2023
-      
+
       - ID: "3.2"
         Title: Data in the Expected Format
         Requirement: >
-          Verify that the data to be ingested matches the format expected by processing algorithms (like pd.DataFrame for CSVs or np.array for images) and adheres to the expected schema.
+          Verify that the data to be ingested matches the format expected by
+          processing algorithms (like pd.DataFrame for CSVs or np.array for
+          images) and adheres to the expected schema.
         Explanation: >
           Ensuring that data and images are in the correct format is essential
           for compatibility with processing tools and algorithms, which may not
@@ -118,7 +133,9 @@ Test Areas:
       - ID: "3.3"
         Title: Data Does Not Contain Null Values or Outliers
         Requirement: >
-          Check that data files are free from unexpected null values and identify any outliers that could affect the analysis. Tests should explicitly state if null values are part of expected data.
+          Check that data files are free from unexpected null values and
+          identify any outliers that could affect the analysis. Tests should
+          explicitly state if null values are part of expected data.
         Explanation: >
           Null values can lead to errors or inaccurate computations in many
           data processing applications, while outliers can distort statistical
@@ -136,7 +153,9 @@ Test Areas:
       - ID: "4.1"
         Title: Cleaning and Transformation Functions Work as Expected
         Requirement: >
-          Test that a fixed input to a function or model produces the expected output, focusing on one verification per test to ensure predictable behavior.
+          Test that a fixed input to a function or model produces the expected
+          output, focusing on one verification per test to ensure predictable
+          behavior.
         Explanation: >
           Fixed input and output during the data cleaning and transformation
           routines should be tested so that no unexpected transformation is
@@ -154,7 +173,9 @@ Test Areas:
       - ID: "5.1"
         Title: Validate Model Input and Output Compatibility
         Requirement: >
-          Confirm that the model accepts inputs of the correct shapes and types and produces outputs that meet the expected shapes and types without any errors.
+          Confirm that the model accepts inputs of the correct shapes and types
+          and produces outputs that meet the expected shapes and types without
+          any errors.
         Explanation: >
           Ensuring that inputs and outputs conform to expected specifications
           is critical for the correct functioning of the model in a production
@@ -165,7 +186,9 @@ Test Areas:
       - ID: "5.2"
         Title: Check Model is Learning During Fit
         Requirement: >
-          For parametric models, ensure that the model's weights update correctly per training iteration. For non-parametric models, verify that the data fits correctly into the model.
+          For parametric models, ensure that the model's weights update
+          correctly per training iteration. For non-parametric models, verify
+          that the data fits correctly into the model.
         Explanation: >
           Making sure the training process is indeed training the model is
           crucial as model without training is not fitted to any data and the
@@ -176,7 +199,9 @@ Test Areas:
       - ID: "5.3"
         Title: Ensure Model Output Shape Aligns with Expectation
         Requirement: >
-          Ensure the shape of the model's output aligns with the expected structure based on the task, such as matching the number of labels in a classification task.
+          Ensure the shape of the model's output aligns with the expected
+          structure based on the task, such as matching the number of labels in
+          a classification task.
         Explanation: >
           Correct output alignment confirms that the model is accurately
           interpreting the input data and making predictions that are sensible
@@ -187,7 +212,9 @@ Test Areas:
       - ID: "5.4"
         Title: Ensure Model Output Aligns with Task Trained
         Requirement: >
-          Verify that the model's output values are appropriate for its task, such as outputting probabilities that sum to 1 for classification tasks.
+          Verify that the model's output values are appropriate for its task,
+          such as outputting probabilities that sum to 1 for classification
+          tasks.
         Explanation: >
           This ensures that the model's output is interpretable and relevant to
           the task it was trained for.
@@ -197,7 +224,9 @@ Test Areas:
       - ID: "5.5"
         Title: Validate Loss Reduction on Gradient Update
         Requirement: >
-          If using gradient descent for training, verify that a single gradient step on a batch of data results in a decrease in the model's training loss.
+          If using gradient descent for training, verify that a single gradient
+          step on a batch of data results in a decrease in the model's training
+          loss.
         Explanation: >
           A decrease in training loss after a gradient update demonstrates that
           the data is adequate to be fitted into the model.
@@ -207,7 +236,9 @@ Test Areas:
       - ID: "5.6"
         Title: Check for Data Leakage
         Requirement: >
-          Confirm that there is no leakage of data between training, validation, and testing sets, or across cross-validation folds, to ensure the integrity of the splits.
+          Confirm that there is no leakage of data between training, validation,
+          and testing sets, or across cross-validation folds, to ensure the
+          integrity of the splits.
         Explanation: >
           Data leakage can compromise the model's ability to generalize to
           unseen data, making it crucial to ensure datasets are properly

--- a/checklist/checklist.yaml
+++ b/checklist/checklist.yaml
@@ -11,11 +11,11 @@ Test Areas:
     Tests:
       - ID: "1.1"
         Title: Write Descriptive Test Names
-        Requirement: >
+        Requirement: >-
           Each test function should have a clear, descriptive name that
           accurately reflects the test's purpose and the specific functionality
           or scenario it examines.
-        Explanation: >
+        Explanation: >-
           If out tests are narrow and sufficiently descriptive, the test name
           itself may give us enough information to start debugging. This also
           helps us to identify what is being tested inside the function.
@@ -25,11 +25,11 @@ Test Areas:
 
       - ID: "1.2"
         Title: Keep Tests Focused
-        Requirement: >
+        Requirement: >-
           Each test should focus on a single scenario, using only one set of
           mock data and testing one specific behavior or outcome to ensure
           clarity and isolate issues.
-        Explanation: >
+        Explanation: >-
           If we test multiple scenarios in a single test, it is hard to idenitfy
           exactly what went wrong. Keeping one scenario in a single test helps
           us to isolate problematic scenarios.
@@ -38,11 +38,11 @@ Test Areas:
 
       - ID: "1.3"
         Title: Prefer Narrow Assertions in Unit Tests
-        Requirement: >
+        Requirement: >-
           Assertions within tests should be focused and narrow. Ensure you are
           only testing relevant behaviors of complex objects and not including
           unrelated assertions.
-        Explanation: >
+        Explanation: >-
           If we have overly wide assertions (such as depending on every field of
           a complex output proto), the test may fail for many unimportant
           reasons. False positives are the opoosite of actionable.
@@ -51,11 +51,11 @@ Test Areas:
 
       - ID: "1.4"
         Title: Keep Cause and Effect Clear
-        Requirement: >
+        Requirement: >-
           Keep any modifications to objects and the corresponding assertions
           close together in your tests to maintain readability and clearly show
           the cause-and-effect relationship.
-        Explanation: >
+        Explanation: >-
           Refrain from using large global test data structures shared across
           multiple unit tests. This will allow for clear identification of each
           test's setup and the cause and effect.
@@ -72,11 +72,11 @@ Test Areas:
     Tests:
       - ID: "2.1"
         Title: Ensure Data File Loads as Expected
-        Requirement: >
+        Requirement: >-
           Ensure that data-loading functions correctly load files when they
           exist and match the expected format, handle non-existent files
           appropriately, and return the expected results.
-        Explanation: >
+        Explanation: >-
           Reading data is a common scenario encountered in ML projects.  This
           item ensures that the data exists and can be loaded with expected
           format, and gracefully exit when unable to load the data.
@@ -85,11 +85,11 @@ Test Areas:
 
       - ID: "2.2"
         Title: Ensure Saving Data/Figures Function Works as Expected
-        Requirement: >
+        Requirement: >-
           Verify that functions for saving data and figures perform write
           operations correctly, checking that the operation succeeds and the
           content matches the expected format.
-        Explanation: >
+        Explanation: >-
           Writing operations create artifacts at different stages of the
           analysis. Making sure the artifacts are created as expected ensures
           that the artifacts we obtained at the end of the analysis would be
@@ -107,10 +107,10 @@ Test Areas:
     Tests:
       - ID: "3.1"
         Title: Files Contain Data
-        Requirement: >
+        Requirement: >-
           Ensure all data files are non-empty and contain the necessary data
           required for further analysis or processing tasks.
-        Explanation: >
+        Explanation: >-
           This checklist item is crucial as it confirms the presence of usable
           data within the files. It prevents errors in later stages of the
           project by ensuring data is available from the start.
@@ -119,11 +119,11 @@ Test Areas:
 
       - ID: "3.2"
         Title: Data in the Expected Format
-        Requirement: >
+        Requirement: >-
           Verify that the data to be ingested matches the format expected by
           processing algorithms (like pd.DataFrame for CSVs or np.array for
           images) and adheres to the expected schema.
-        Explanation: >
+        Explanation: >-
           Ensuring that data and images are in the correct format is essential
           for compatibility with processing tools and algorithms, which may not
           handle unexpected formats gracefully.
@@ -132,11 +132,11 @@ Test Areas:
 
       - ID: "3.3"
         Title: Data Does Not Contain Null Values or Outliers
-        Requirement: >
+        Requirement: >-
           Check that data files are free from unexpected null values and
           identify any outliers that could affect the analysis. Tests should
           explicitly state if null values are part of expected data.
-        Explanation: >
+        Explanation: >-
           Null values can lead to errors or inaccurate computations in many
           data processing applications, while outliers can distort statistical
           analyses and models. As such, these values should be checked when
@@ -152,11 +152,11 @@ Test Areas:
     Tests:
       - ID: "4.1"
         Title: Cleaning and Transformation Functions Work as Expected
-        Requirement: >
+        Requirement: >-
           Test that a fixed input to a function or model produces the expected
           output, focusing on one verification per test to ensure predictable
           behavior.
-        Explanation: >
+        Explanation: >-
           Fixed input and output during the data cleaning and transformation
           routines should be tested so that no unexpected transformation is
           introduced during these steps.
@@ -172,11 +172,11 @@ Test Areas:
     Tests:
       - ID: "5.1"
         Title: Validate Model Input and Output Compatibility
-        Requirement: >
+        Requirement: >-
           Confirm that the model accepts inputs of the correct shapes and types
           and produces outputs that meet the expected shapes and types without
           any errors.
-        Explanation: >
+        Explanation: >-
           Ensuring that inputs and outputs conform to expected specifications
           is critical for the correct functioning of the model in a production
           environment.
@@ -185,11 +185,11 @@ Test Areas:
 
       - ID: "5.2"
         Title: Check Model is Learning During Fit
-        Requirement: >
+        Requirement: >-
           For parametric models, ensure that the model's weights update
           correctly per training iteration. For non-parametric models, verify
           that the data fits correctly into the model.
-        Explanation: >
+        Explanation: >-
           Making sure the training process is indeed training the model is
           crucial as model without training is not fitted to any data and the
           performance would suffer.
@@ -198,11 +198,11 @@ Test Areas:
 
       - ID: "5.3"
         Title: Ensure Model Output Shape Aligns with Expectation
-        Requirement: >
+        Requirement: >-
           Ensure the shape of the model's output aligns with the expected
           structure based on the task, such as matching the number of labels in
           a classification task.
-        Explanation: >
+        Explanation: >-
           Correct output alignment confirms that the model is accurately
           interpreting the input data and making predictions that are sensible
           given the context.
@@ -211,11 +211,11 @@ Test Areas:
 
       - ID: "5.4"
         Title: Ensure Model Output Aligns with Task Trained
-        Requirement: >
+        Requirement: >-
           Verify that the model's output values are appropriate for its task,
           such as outputting probabilities that sum to 1 for classification
           tasks.
-        Explanation: >
+        Explanation: >-
           This ensures that the model's output is interpretable and relevant to
           the task it was trained for.
         References:
@@ -223,11 +223,11 @@ Test Areas:
 
       - ID: "5.5"
         Title: Validate Loss Reduction on Gradient Update
-        Requirement: >
+        Requirement: >-
           If using gradient descent for training, verify that a single gradient
           step on a batch of data results in a decrease in the model's training
           loss.
-        Explanation: >
+        Explanation: >-
           A decrease in training loss after a gradient update demonstrates that
           the data is adequate to be fitted into the model.
         References:
@@ -235,11 +235,11 @@ Test Areas:
 
       - ID: "5.6"
         Title: Check for Data Leakage
-        Requirement: >
+        Requirement: >-
           Confirm that there is no leakage of data between training, validation,
           and testing sets, or across cross-validation folds, to ensure the
           integrity of the splits.
-        Explanation: >
+        Explanation: >-
           Data leakage can compromise the model's ability to generalize to
           unseen data, making it crucial to ensure datasets are properly
           segregated.

--- a/src/checklist/checklist.py
+++ b/src/checklist/checklist.py
@@ -1,20 +1,127 @@
 import os
+import csv
+from enum import Enum
 from typing import Union
+from abc import ABC, abstractmethod
 
 import fire
 from ruamel.yaml import YAML
 
 
-class Checklist:
-    def __init__(self, checklist_path: str):
-        if not os.path.exists(checklist_path):
-            raise FileNotFoundError("Checklist file not found.")
+def filter_dict(d: dict, keys: list) -> dict:
+    return {k: v for k, v in d.items() if k in keys}
+
+
+class ChecklistFormat(Enum):
+    YAML = 1
+    CSV = 2
+
+
+class ChecklistIO(ABC):
+    @abstractmethod
+    def read(self, path: str) -> dict:
+        pass
+
+    @abstractmethod
+    def write(self, path: str, data: dict) -> None:
+        pass
+
+
+class YamlChecklistIO(ChecklistIO):
+    @classmethod
+    def read(cls, path: str) -> dict:
         try:
-            with open(checklist_path, "r") as f:
-                self.content = YAML(typ="safe").load(f)
-            self.test_areas = set([x["Topic"] for x in self.content["Test Areas"]])
+            with open(path, "r") as f:
+                content = YAML(typ="safe").load(f)
+            return content
         except Exception as e:
             raise SyntaxError("Failed to parse the checklist. Make sure that it is a YAML 1.2 document.")
+
+    @classmethod
+    def write(cls, path: str, data: dict) -> None:
+        yaml = YAML()
+        yaml.indent(sequence=4, offset=2)
+        yaml.default_flow_style = False
+        with open(path, "w") as f:
+            yaml.dump(data, f)
+
+
+class CsvChecklistIO(ChecklistIO):
+    overview_field_names_unnested = ["Title", "Description"]
+    topics_field_names_unnested = ["ID", "Topic", "Description"]
+    tests_field_names_unnested = ["ID", "Title", "Requirement", "Explanation", "References"]
+    overview_field_name_nested = "Test Areas"
+    topics_field_name_nested = "Tests"
+    overview_filename = "overview.csv"
+    topics_filename = "topics.csv"
+    tests_filename = "tests.csv"
+
+    @staticmethod
+    def _read_file(path: str) -> list:
+        with open(path, "r") as f:
+            reader = csv.DictReader(f)
+            results = list(reader)
+        return results
+
+    @staticmethod
+    def _write_file(path: str, items: list, field_names: list) -> None:
+        with open(path, "w") as f:
+            w = csv.DictWriter(f, fieldnames=field_names)
+            w.writeheader()
+            for item in items:
+                w.writerow(item)
+
+    @classmethod
+    def read(cls, path: str) -> dict:
+        try:
+            if not os.path.isdir(path):
+                raise NotADirectoryError("Checklist path is not a directory.")
+            ov_filepath = os.path.join(path, cls.overview_filename)
+            to_filepath = os.path.join(path, cls.topics_filename)
+            te_filepath = os.path.join(path, cls.tests_filename)
+            if not os.path.isfile(ov_filepath) or not os.path.isfile(to_filepath) or not os.path.isfile(te_filepath):
+                raise FileNotFoundError("All three CSV files must be present in the directory.")
+
+            overview = cls._read_file(ov_filepath)
+            topics = cls._read_file(to_filepath)
+            tests = cls._read_file(te_filepath)
+
+            for topic in topics:
+                topic_id = topic["ID"]
+                topic_tests = [test for test in tests if test["ID"].startswith(topic_id)]
+                topic[cls.topics_field_name_nested] = topic_tests
+
+            content = overview[0]
+            content[cls.overview_field_name_nested] = topics
+            return content
+
+        except Exception as e:
+            raise SyntaxError("Failed to parse the checklist. Make sure that it is a directory containing CSV files.")
+
+    @classmethod
+    def write(cls, path: str, data: dict) -> None:
+        os.makedirs(path, exist_ok=True)
+        overview = [filter_dict(data, cls.overview_field_names_unnested)]
+        topics = [filter_dict(area, cls.topics_field_names_unnested) for area in data["Test Areas"]]
+        tests = sum([area["Tests"] for area in data["Test Areas"]], [])
+
+        cls._write_file(os.path.join(path, cls.overview_filename), overview, cls.overview_field_names_unnested)
+        cls._write_file(os.path.join(path, cls.topics_filename), topics, cls.topics_field_names_unnested)
+        cls._write_file(os.path.join(path, cls.tests_filename), tests, cls.tests_field_names_unnested)
+
+
+class Checklist:
+    def __init__(self, checklist_path: str, checklist_format: ChecklistFormat):
+        if not os.path.exists(checklist_path):
+            raise FileNotFoundError("Checklist file not found.")
+        if checklist_format == ChecklistFormat.YAML:
+            self.content = YamlChecklistIO.read(checklist_path)
+        elif checklist_format == ChecklistFormat.CSV:
+            self.content = CsvChecklistIO.read(checklist_path)
+        else:
+            raise NotImplementedError(f"Format {checklist_format} is not supported.")
+
+        self.test_areas = set([x["Topic"] for x in self.content["Test Areas"]])
 
     def get_tests_by_areas(self, areas: Union[list, str, set], requirements_only: bool = False):
         tests = []
@@ -25,7 +132,7 @@ class Checklist:
         if not areas_set.issubset(self.test_areas):
             raise KeyError("The provided areas has one or more items that is not present in the checklist.")
 
-        areas = [ x for x in self.content["Test Areas"] if x["Topic"] in areas ]
+        areas = [x for x in self.content["Test Areas"] if x["Topic"] in areas]
         for area in areas:
             if requirements_only:
                 tests += [x.get("Requirement") for x in area["Tests"]]
@@ -39,13 +146,37 @@ class Checklist:
     def get_test_areas(self):
         return self.test_areas
 
+    def to_yaml(self, output_path: str, no_preserve_format: bool = False, exist_ok: bool = False):
+        if not no_preserve_format:
+            raise NotImplementedError(
+                "Roundtripping is not yet implemented. If you want to dump the YAML file disregarding the original "
+                "formatting, use `no_preserve_format=True`."
+            )
+        elif not exist_ok and os.path.exists(output_path):
+            raise FileExistsError("Output file already exists. Use `exist_ok=True` to overwrite.")
+        YamlChecklistIO.write(output_path, self.content)
+
+    def to_csv(self, output_path, exist_ok: bool = False):
+        """Dump the checklist to three separate CSV files."""
+        if not exist_ok and os.path.exists(output_path):
+            raise FileExistsError("Output file already exists. Use `exist_ok=True` to overwrite.")
+        CsvChecklistIO.write(output_path, self.content)
+
 
 if __name__ == "__main__":
     def example(checklist_path: str):
-        """Example calls. To be removed later."""
-        checklist = Checklist(checklist_path)
-        # tests = checklist.get_tests_by_areas("General", requirements_only=False)
-        tests = checklist.get_all_tests()
-        print(tests)
+        """Example calls. To be removed later.
+
+        Example:
+        python src/checklist/checklist.py ./test-dump-csv/
+
+        Note that the supplied path must be a directory containing 3 CSV files:
+        1. `overview.csv`
+        2. `topics.csv`
+        3. `tests.csv`
+        """
+        checklist = Checklist(checklist_path, checklist_format=ChecklistFormat.CSV)
+        checklist.to_yaml("test-dump.yaml", no_preserve_format=True, exist_ok=True)
+
 
     fire.Fire(example)

--- a/src/checklist/checklist.py
+++ b/src/checklist/checklist.py
@@ -49,10 +49,11 @@ class YamlChecklistIO(ChecklistIO):
 
 class CsvChecklistIO(ChecklistIO):
     overview_field_names_unnested = ["Title", "Description"]
-    topics_field_names_unnested = ["ID", "Topic", "Description"]
-    tests_field_names_unnested = ["ID", "Topic", "Title", "Requirement", "Explanation", "References"]
     overview_field_name_nested = "Test Areas"
+    topics_field_names_unnested = ["ID", "Topic", "Description"]
     topics_field_name_nested = "Tests"
+    tests_field_names_unnested = ["ID", "Topic", "Title", "Requirement", "Explanation", "References"]
+    tests_field_names_ignore = ["Topic"]
     overview_filename = "overview.csv"
     topics_filename = "topics.csv"
     tests_filename = "tests.csv"
@@ -99,6 +100,10 @@ class CsvChecklistIO(ChecklistIO):
                 test['References'] = test['References'].split(',')
                 test['References'] = [x.strip(' ') for x in test['References']]
 
+                # remove keys to be ignored (i.e. not included) in the constructed dictionary
+                for key in cls.tests_field_names_ignore:
+                    test.pop(key, None)
+
             content = overview[0]
             content[cls.overview_field_name_nested] = topics
             return content
@@ -111,7 +116,6 @@ class CsvChecklistIO(ChecklistIO):
         os.makedirs(path, exist_ok=True)
         overview = [filter_dict(data, cls.overview_field_names_unnested)]
         topics = [filter_dict(area, cls.topics_field_names_unnested) for area in data["Test Areas"]]
-        tests = sum([area["Tests"] for area in data["Test Areas"]], [])
 
         # change the representation of tests:
         # 1. Add `Topic` from the parent Topic

--- a/src/checklist/checklist.py
+++ b/src/checklist/checklist.py
@@ -88,7 +88,9 @@ class CsvChecklistIO(ChecklistIO):
 
             for topic in topics:
                 topic_id = topic["ID"]
-                topic_tests = [test for test in tests if test["ID"].startswith(topic_id)]
+                # matches all tests with ID that starts with the same as current topic ID
+                # this assumes that the test item ID would contain a dot i.e. `.`.
+                topic_tests = [test for test in tests if test["ID"].split(".")[0] == topic_id]
                 topic[cls.topics_field_name_nested] = topic_tests
 
             content = overview[0]
@@ -175,8 +177,9 @@ if __name__ == "__main__":
         2. `topics.csv`
         3. `tests.csv`
         """
-        checklist = Checklist(checklist_path, checklist_format=ChecklistFormat.CSV)
-        checklist.to_yaml("test-dump.yaml", no_preserve_format=True, exist_ok=True)
+        checklist = Checklist(checklist_path, checklist_format=ChecklistFormat.YAML)
+        checklist.to_csv("./checklist/csv/", exist_ok=False)
+        # checklist.to_yaml("test-dump.yaml", no_preserve_format=True, exist_ok=True)
 
 
     fire.Fire(example)

--- a/src/checklist/checklist.py
+++ b/src/checklist/checklist.py
@@ -91,12 +91,15 @@ class CsvChecklistIO(ChecklistIO):
             for topic in topics:
                 topic_id = topic["ID"]
                 # matches all tests with ID that starts with the same as current topic ID
-                # this assumes that the test item ID would contain a dot i.e. `.`.
+                # this assumes that the test item ID would contain a dot i.e. `.` and
+                # follows the format `{topic-id}.{test-number}`, where the `{test-number}
+                # is an incremental number to indicate the ordering of the test within
+                # a topic.
                 topic_tests = [test for test in tests if test["ID"].split(".")[0] == topic_id]
                 topic[cls.topics_field_name_nested] = topic_tests
 
             for test in tests:
-                # convert the references back into a list
+                # convert the references back into a list from its joined string representation
                 test['References'] = test['References'].split(',')
                 test['References'] = [x.strip(' ') for x in test['References']]
 
@@ -180,9 +183,9 @@ class Checklist:
         YamlChecklistIO.write(output_path, self.content)
 
     def to_csv(self, output_path, exist_ok: bool = False):
-        """Dump the checklist to three separate CSV files."""
+        """Dump the checklist to a directory containing three separate CSV files."""
         if not exist_ok and os.path.exists(output_path):
-            raise FileExistsError("Output file already exists. Use `exist_ok=True` to overwrite.")
+            raise FileExistsError("Output directory already exists. Use `exist_ok=True` to overwrite.")
         CsvChecklistIO.write(output_path, self.content)
 
 


### PR DESCRIPTION
This PR:
- Modifies the existing YAML checklist to add an attribute `ID` for every test area and test item
- Adds two new methods `to_yaml` and `to_csv` to class `Checklist` in order to export (dump) YAML and/or CSV files
- Extends `Checklist`'s capability to read checklist items from CSV files

The CSV files must be in specific format exported by `Checklist`. Please refer to the example calls to see how to read CSV files.

Closes #66 .