### PR TITLE
feat: Extend the checklists loader functionality to export the checklist in htmlpdf format for visualization

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,16 +4,17 @@ channels:
   - defaults
   - anaconda
 dependencies:
+  - fire=0.6.0
   - jupyter-book=0.15
   - jupyterlab=4.0
+  - langchain=0.1.16
   - pandas=2.2.2
   - pip=24.0
   - pypandoc=1.6.3
   - python=3.12
   - python-dotenv=1.0.1
-  - fire=0.6.0
-  - langchain=0.1.16
   - ruamel.yaml=0.18.6
+  - tectonic=0.15.0
   - tqdm=4.66.4
   - pip:
     - distro==1.9.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - jupyterlab=4.0
   - pandas=2.2.2
   - pip=24.0
+  - pypandoc=1.6.3
   - python=3.12
   - python-dotenv=1.0.1
   - fire=0.6.0

--- a/src/test_creation/modules/checklist/checklist.py
+++ b/src/test_creation/modules/checklist/checklist.py
@@ -209,12 +209,12 @@ class Checklist:
 
         # handle repeated columns and references
         for k in repeated_col:
-            if k not in ['References']:
+            if k != 'References':
                 for item in content[k]:
                     md_repr += self._get_md_representation(item, curr_level=curr_level + 1)
-            elif k == 'References':
+            else:
                 md_repr += '**References:**\n\n' + '\n'.join(f'  - {item}' for item in content['References']) + '\n\n'
-        # md_repr += '\n'
+
         return md_repr
 
     @staticmethod
@@ -253,7 +253,7 @@ if __name__ == "__main__":
         """
         checklist = Checklist(checklist_path, checklist_format=ChecklistFormat.CSV)
         print(checklist.as_markdown())
-        checklist.export_quarto("checklist.pdf", exist_ok=True)
+        checklist.export_pdf("checklist.pdf", exist_ok=True)
 
 
     fire.Fire(example)

--- a/src/test_creation/modules/checklist/checklist.py
+++ b/src/test_creation/modules/checklist/checklist.py
@@ -229,7 +229,8 @@ class Checklist:
 
     def export_pdf(self, output_path: str, exist_ok: bool = False):
         self.__filedump_check(output_path, exist_ok)
-        pypandoc.convert_text(self.as_markdown(), 'pdf', format='md', outputfile=output_path)
+        pypandoc.convert_text(self.as_markdown(), 'pdf', format='md', outputfile=output_path,
+                              extra_args=['--pdf-engine=tectonic'])
 
     def export_quarto(self, output_path: str, exist_ok: bool = False):
         self.__filedump_check(output_path, exist_ok)

--- a/src/test_creation/modules/checklist/checklist.py
+++ b/src/test_creation/modules/checklist/checklist.py
@@ -225,11 +225,11 @@ class Checklist:
 
     def export_html(self, output_path: str, exist_ok: bool = False):
         self.__filedump_check(output_path, exist_ok)
-        pypandoc.convert_text(self.as_markdown(), 'html', format='md', outputfile='checklist.html')
+        pypandoc.convert_text(self.as_markdown(), 'html', format='md', outputfile=output_path)
 
     def export_pdf(self, output_path: str, exist_ok: bool = False):
         self.__filedump_check(output_path, exist_ok)
-        pypandoc.convert_text(self.as_markdown(), 'pdf', format='md', outputfile='checklist.pdf')
+        pypandoc.convert_text(self.as_markdown(), 'pdf', format='md', outputfile=output_path)
 
     def export_quarto(self, output_path: str, exist_ok: bool = False):
         self.__filedump_check(output_path, exist_ok)
@@ -241,7 +241,6 @@ class Checklist:
 
 if __name__ == "__main__":
     def example(checklist_path: str):
-        import pprint
         """Example calls. To be removed later.
 
         Example:
@@ -253,9 +252,8 @@ if __name__ == "__main__":
         3. `tests.csv`
         """
         checklist = Checklist(checklist_path, checklist_format=ChecklistFormat.CSV)
-        # pprint.pprint(checklist.get_all_tests())
         print(checklist.as_markdown())
-        checklist.export_quarto("checklist.qmd", exist_ok=True)
+        checklist.export_quarto("checklist.pdf", exist_ok=True)
 
 
     fire.Fire(example)

--- a/src/test_creation/modules/checklist/checklist.py
+++ b/src/test_creation/modules/checklist/checklist.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         """Example calls. To be removed later.
 
         Example:
-        python src/checklist/checklist.py ./test-dump-csv/
+        python src/test_creation/modules/checklist/checklist.py ./checklist/test-dump-csv
 
         Note that the supplied path must be a directory containing 3 CSV files:
         1. `overview.csv`


### PR DESCRIPTION
This PR:
- add pypandoc as dependency
- add feature to represent the checklist as markdown string
- add feature to export checklist in HTML/PDF/qmd formats

[Here is a sample of the exported checklist.pdf.](https://github.com/UBC-MDS/test-creation/files/15396112/checklist.pdf)

Closes #84.


