### PR TITLE
fix: Fix errors produced against repos for demo session

### DIFF
--- a/src/test_creation/modules/code_analyzer/repo.py
+++ b/src/test_creation/modules/code_analyzer/repo.py
@@ -152,9 +152,13 @@ class Repository:
                         ast.read(file)
                         file_function_lineno_map[lang][file] = ast._get_function_lineno_map()
                     except Exception as e:
-                        logger.info("Exception occurred when parsing using ast (Python 2 code?) Using naive parser...")
-                        naive.read(file)
-                        file_function_lineno_map[lang][file] = naive._get_function_lineno_map()
+                        try:
+                            logger.info("Exception occurred when parsing using ast (Python 2 code?) Using naive parser...")
+                            naive.read(file)
+                            file_function_lineno_map[lang][file] = naive._get_function_lineno_map()
+                        except Exception as e:
+                            logger.info("Still failed to parse the file! "
+                                        "Skipping the file...")
         return file_function_lineno_map
 
     def list_languages(self):

--- a/src/test_creation/modules/workflow/prompt_format.py
+++ b/src/test_creation/modules/workflow/prompt_format.py
@@ -40,7 +40,9 @@ class EvaluationPromptFormat(PromptFormat):
                      "{format_instructions}\n"
                      "For a test item to be considered as `Satisfied` or `Partially Satisfied`, "
                      "the corresponding function(s) satisfying the item's requirement must be "
-                     "provided in the `Functions` attribute.\n"
+                     "provided in the `Functions` attribute. For every item "
+                     "in the checklist, you must provide an evaluation, "
+                     "even if the tests are not related to the item in any way.\n"
                      "Here is the checklist as a list of JSON objects:\n```{checklist}```\n"
                      "Here is the code to be analyzed:\n```{codebase}```",
             description="Code Review for Machine Learning Project",

--- a/src/test_creation/modules/workflow/runners/evaluator.py
+++ b/src/test_creation/modules/workflow/runners/evaluator.py
@@ -77,7 +77,8 @@ class PerFileTestEvaluator(PromptInjectionRunner):
             retry_count = 0
             start_time = datetime.now()
 
-            context = {"codebase": splits, "checklist": json.dumps(self._test_items)}
+            context = {"codebase": str(splits),
+                       "checklist": json.dumps(self._test_items)}
 
             while not response and retry_count < self.retries:
                 try:


### PR DESCRIPTION
This PR addresses the errors discovered when running repos for thursday's demo session.

This includes:
- stringlify content to be saved in `EvaluationResponse.context.codebase`
- improve prompt provide more rigid guidance to make sure LLM returns every checklist item
- add fallback actions to take when failed to read/parse files
- remove preemptive encoding detection and put it as fallback to prevent wrong detection

Here are the screen shots showing the fixed code running evaluation on the repos:

## qlib
<img width="711" alt="image" src="https://github.com/UBC-MDS/test-creation/assets/17952490/f18623b4-0923-4c68-ba32-7e48edcb9517">
<img width="2499" alt="image" src="https://github.com/UBC-MDS/test-creation/assets/17952490/de122275-b58d-40a7-b34b-dd9a5f52c796">

## dsci_522_group_8_bank_marketing_project
<img width="2492" alt="image" src="https://github.com/UBC-MDS/test-creation/assets/17952490/e88462df-8ed9-4025-8ce5-407ff3065c05">

## group21_top-three-predictors-of-term-deposit-subscriptions
<img width="2501" alt="image" src="https://github.com/UBC-MDS/test-creation/assets/17952490/0abe484e-17e9-4221-9cf8-cc02e04c100a">
